### PR TITLE
Add support for entry from reddit home page

### DIFF
--- a/background.js
+++ b/background.js
@@ -18,6 +18,7 @@ const tickersToFilter = [
   "BUY",
   "LEAP",
   "PUMP",
+  "API",
 ];
 
 /**

--- a/content-script.js
+++ b/content-script.js
@@ -11,12 +11,23 @@ const SUPPORTED_SUBREDDITS = new Set([
 function isSupportedSubreddit() {
   const url = location.href;
   const subredditStartIndex = url.indexOf(SUBREDDIT_INDICATOR);
-  if (subredditNameStartIndex === -1) {
+  if (subredditStartIndex === -1) {
     return false;
   }
-  const subredditName = url.substring(
-    subredditStartIndex + SUBREDDIT_INDICATOR.length
-  );
+
+  const subredditNameStartIndex =
+    subredditStartIndex + SUBREDDIT_INDICATOR.length;
+
+  // Search for trailing slash (e.g. / at end of https://www.reddit.com/r/wallstreetbets/)
+  // to know the subreddit name end index
+  const subredditNameEndIndex = url.indexOf("/", subredditNameStartIndex);
+  const subredditName = url
+    .substring(
+      subredditNameStartIndex,
+      // Only include trailing slash index if trailing slash was found
+      subredditNameEndIndex !== -1 ? subredditNameEndIndex : undefined
+    )
+    .toLowerCase();
   return SUPPORTED_SUBREDDITS.has(subredditName);
 }
 

--- a/content-script.js
+++ b/content-script.js
@@ -1,4 +1,29 @@
+const SUBREDDIT_INDICATOR = "/r/";
+
+const SUPPORTED_SUBREDDITS = new Set([
+  "options",
+  "stocks",
+  "investing",
+  "thetagang",
+  "wallstreetbets",
+]);
+
+function isSupportedSubreddit() {
+  const url = location.href;
+  const subredditStartIndex = url.indexOf(SUBREDDIT_INDICATOR);
+  if (subredditNameStartIndex === -1) {
+    return false;
+  }
+  const subredditName = url.substring(
+    subredditStartIndex + SUBREDDIT_INDICATOR.length
+  );
+  return SUPPORTED_SUBREDDITS.has(subredditName);
+}
+
 function enrichSearchResults(contextNode = document) {
+  if (!isSupportedSubreddit()) {
+    return;
+  }
   const redditPostLinks = document.evaluate(
     `//div[contains(@class,"Post") and not(@rsh-processed)]`,
     contextNode,

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "content_scripts": [
     {
       "matches": [
+        "https://www.reddit.com/",
         "https://www.reddit.com/r/options*",
         "https://www.reddit.com/r/stocks*",
         "https://www.reddit.com/r/investing*",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Reddit Stocks",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Adds stock prices and percent change to posts on stock-related subreddits",
   "manifest_version": 2,
   "content_scripts": [


### PR DESCRIPTION
Add support for activating the Chrome extension when you first navigate to the Reddit home page rather than just when navigating to specific subreddits. This is done since Reddit uses frontend routing. A check is still done to ensure you are in a specific subreddit before actually displaying ticker prices on all the posts.